### PR TITLE
Update gumby.parallax.js

### DIFF
--- a/gumby.parallax.js
+++ b/gumby.parallax.js
@@ -1,7 +1,7 @@
 /**
 * Gumby Parallax
 */
-!function() {
+!function($) {
 
 	'use strict';
 
@@ -102,4 +102,4 @@
 			Gumby.initialize('parallax');
 		}
 	});
-}();
+}(jQuery);


### PR DESCRIPTION
Pass in jQuery for use cases where jQuery is in no conflict mode, such as WordPress.
