### PR TITLE
Use position() instead of offset()

### DIFF
--- a/gumby.parallax.js
+++ b/gumby.parallax.js
@@ -52,7 +52,7 @@
 		}
 
 		// calculate starting bg position
-		this.startPos = ((this.$el.offset().top - this.offset) * this.ratio);
+		this.startPos = ((this.$el.position().top - this.offset) * this.ratio);
 
 		// find holder element
 		if(this.$holder) {
@@ -66,7 +66,7 @@
 		// holder is set and not window so add to offset calc
 		} else {
 			// calculate starting bg position
-			this.startPos -= this.$holder.offset().top;
+			this.startPos -= this.$holder.position().top;
 		}
 	};
 


### PR DESCRIPTION
I had an issue when using parallax on a div with 'position: fixed' and 'top: 0'. The start position of the background was off if the page was loaded scrolled. The fix doesn't seem to have any negative impact afaik.